### PR TITLE
Fix method name in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ class MySample
   def clean
     clear
   end
-  deprecate :clean, :clear, 'next version'
+  deprecated :clean, :clear, 'next version'
 
 end
 ```


### PR DESCRIPTION
The example in the readme has an incorrect method name and does not run.  This fixes that.